### PR TITLE
add agent_job_state_duration_seconds metric

### DIFF
--- a/fixtures/111_agent_job_history_0.json
+++ b/fixtures/111_agent_job_history_0.json
@@ -1,0 +1,25 @@
+{
+  "jobs": [
+    {
+      "agent_uuid": "111",
+      "name": "upload",
+      "pipeline_name": "distributions-all",
+      "result": "Passed",
+      "id": 2,
+      "stage_name": "upload-installers"
+    },
+    {
+      "agent_uuid": "111",
+      "name": "upload",
+      "pipeline_name": "distributions-all",
+      "result": "Failed",
+      "id": 1,
+      "stage_name": "upload-installers"
+    }
+  ],
+  "pagination": {
+    "offset": 0,
+    "total": 2,
+    "page_size": 10
+  }
+}


### PR DESCRIPTION
In order to measure job durations the agent_job_state_duration_seconds
exposes all state transition durations for a job from the gocd api.