### PR TITLE
HAWK-222 Add support for retrieving state transitions in chronological order

### DIFF
--- a/agent_job_history_test.go
+++ b/agent_job_history_test.go
@@ -56,3 +56,30 @@ func TestGetJobHistory(t *testing.T) {
 		t.Fatal("Unexpected job id")
 	}
 }
+
+func TestGetOrderedTransitions(t *testing.T) {
+	a := &AgentJobHistory{}
+	cache := AgentJobHistoryCache{}
+	client := &MockClient{}
+	agents, _ := client.GetAllAgents()
+
+	_ = a.GetJobHistory(client, agents, cache, 1)
+
+	ajh := a.AgentJobHistory["bazagent"]
+	st := ajh[0].GetOrderedStateTransitions()
+	if st[0].State != "Scheduled" {
+		t.Fatal("Transitions not sorted, expected 'Scheduled' got ", st[0].State)
+	}
+	if st[1].State != "Assigned" {
+		t.Fatal("Transitions not sorted, expected 'Assigned' got ", st[1].State)
+	}
+	if st[2].State != "Preparing" {
+		t.Fatal("Transitions not sorted, expected 'Preparing' got ", st[2].State)
+	}
+	if st[3].State != "Building" {
+		t.Fatal("Transitions not sorted, expected 'Building' got ", st[3].State)
+	}
+	if st[4].State != "Rescheduled" {
+		t.Fatal("Transitions not sorted, expected 'Rescheduled' got ", st[4].State)
+	}
+}

--- a/fixtures/789_agent_job_history_0.json
+++ b/fixtures/789_agent_job_history_0.json
@@ -6,7 +6,34 @@
       "result": "Passed",
       "id": 2,
       "name": "jobname",
-      "stage_name": "stagename"
+      "stage_name": "stagename",
+      "job_state_transitions": [
+        {
+          "state": "Building",
+          "state_change_time": 4,
+          "id": 4
+        },
+        {
+          "state": "Scheduled",
+          "state_change_time": 1,
+          "id": 1
+        },
+        {
+          "state": "Assigned",
+          "state_change_time": 2,
+          "id": 2
+        },
+        {
+          "state": "Preparing",
+          "state_change_time": 3,
+          "id": 3
+        },
+        {
+          "state": "Rescheduled",
+          "state_change_time": 5,
+          "id": 5
+        }
+      ]
     }
   ],
   "pagination": {

--- a/scraper.go
+++ b/scraper.go
@@ -436,9 +436,8 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 					a.Hostname, jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,
 				).Inc()
 
-				transitions := jobHistory.JobStateTransitions
 				prevTime := jobHistory.ScheduledDate
-				for _, t := range transitions {
+				for _, t := range jobHistory.GetOrderedStateTransitions() {
 					duration := (t.StateChangeTime - prevTime) / 1000
 					agentJobDurationGauge.WithLabelValues(
 						t.State, a.Hostname, jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,


### PR DESCRIPTION
The state transitions are not always returned in chronological order by the GoCD api. This adds support for retrieving them in order by sorting on the state_change_time timestamp that's included in each transition.