### PR TITLE
HAWK-654 remove agent dimension for jobs

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
-github.com/pagero/go-gocd-ashwanth v0.0.0-20210408150919-9e29c6be9aa6 h1:JPyWn9Ohncuoz6e57q25wEdAUu4DhQEACUuRrbLVM2g=
-github.com/pagero/go-gocd-ashwanth v0.0.0-20210408150919-9e29c6be9aa6/go.mod h1:7yfV81TaZxdJE5paFZZZWvWXn7qO+gKamUFkvNpqkF8=
 github.com/pagero/go-gocd-ashwanth v0.0.0-20210409065851-495ee9554647 h1:+ZxHhq2L6iOXy3EfN2QVu8ZO1xN1CPw4i3+eihWa/6g=
 github.com/pagero/go-gocd-ashwanth v0.0.0-20210409065851-495ee9554647/go.mod h1:7yfV81TaZxdJE5paFZZZWvWXn7qO+gKamUFkvNpqkF8=
 github.com/parnurzeal/gorequest v0.2.16 h1:T/5x+/4BT+nj+3eSknXmCTnEVGSzFzPGdpqmUVVZXHQ=

--- a/scraper.go
+++ b/scraper.go
@@ -288,7 +288,7 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			Name:      "agent_job_results",
 			Help:      "Aggregated sum of job results per agent",
 		},
-		[]string{"agent", "pipeline", "pipeline_group", "stage", "job", "result"},
+		[]string{"pipeline", "pipeline_group", "stage", "job", "result"},
 	)
 	agentJobDurationGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -296,7 +296,7 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			Name:      "agent_job_state_duration_seconds",
 			Help:      "job state transition durations - Limitations: running the exporter with a longer scrape interval could make this metric being overwritten if a job is run on the same agent several times within the scrape interval period.",
 		},
-		[]string{"state", "agent", "pipeline", "pipeline_group", "stage", "job", "result"},
+		[]string{"state", "pipeline", "pipeline_group", "stage", "job", "result"},
 	)
 	agentCountGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -327,7 +327,6 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			"rerun",
 			"state",
 			"result",
-			"agent",
 		},
 	)
 	agentFreeSpaceGauge := prometheus.NewGaugeVec(
@@ -391,7 +390,7 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			}
 			jobStats = append(jobStats, []string{
 				pGroup, job.PipelineName, job.StageName, job.Name,
-				rerun, job.State, job.Result, a.Hostname,
+				rerun, job.State, job.Result,
 			})
 		}
 
@@ -417,7 +416,7 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 				}
 
 				agentJobResultCounter.WithLabelValues(
-					a.Hostname, jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,
+					jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,
 				).Inc()
 
 				prevTime, err := jobHistory.getScheduled()
@@ -431,7 +430,7 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 					}
 					duration := stateTime.Unix() - prevTime
 					agentJobDurationGauge.WithLabelValues(
-						t.State, a.Hostname, jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,
+						t.State, jobHistory.PipelineName, pGroup, jobHistory.StageName, jobHistory.Name, jobHistory.Result,
 					).Set(float64(duration))
 					prevTime = stateTime.Unix()
 				}

--- a/scraper.go
+++ b/scraper.go
@@ -329,19 +329,9 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			"result",
 		},
 	)
-	agentFreeSpaceGauge := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: conf.Namespace,
-			Name:      "agent_free_space_bytes",
-			Help:      "Available bytes on agent storage",
-		},
-		[]string{
-			"agent",
-		},
-	)
 
 	client := gocd.New(conf.GocdURL, conf.GocdUser, conf.GocdPass)
-	return []prometheus.Collector{agentCountGauge, agentJobGauge, agentFreeSpaceGauge, agentJobResultCounter, agentJobDurationGauge}, func(ctx context.Context) error {
+	return []prometheus.Collector{agentCountGauge, agentJobGauge, agentJobResultCounter, agentJobDurationGauge}, func(ctx context.Context) error {
 		agents, err := client.GetAllAgents()
 		if err != nil {
 			return err
@@ -355,12 +345,6 @@ func newAgentCollector(conf *Config, agentJobHistoryCache AgentJobHistoryCache, 
 			agentCountGauge.WithLabelValues(
 				a.BuildState, a.AgentState, a.AgentConfigState,
 			).Add(1)
-		}
-		agentFreeSpaceGauge.Reset()
-		for _, a := range agents {
-			agentFreeSpaceGauge.WithLabelValues(
-				a.Hostname,
-			).Set(float64(a.FreeSpace))
 		}
 
 		// Slower scrape for each job history


### PR DESCRIPTION
Remove the agent dimension for gocd jobs as our agents are short lived this dimension don't give us much info.

Also remove metrics for flapping pipelines and agent free disk space as we don't use them anymore.